### PR TITLE
Fix publication and presentation links

### DIFF
--- a/_presentations/achems-2024-multiscale.md
+++ b/_presentations/achems-2024-multiscale.md
@@ -4,5 +4,5 @@ authors: "Rafilson et al."
 event: "Association for Chemoreception Sciences (AChemS)"
 year: 2024
 poster: "/assets/posters/AChemS_2024.pdf"
-slides: ""
+slides:
 ---

--- a/_presentations/achems-2025-sniffing-place.md
+++ b/_presentations/achems-2025-sniffing-place.md
@@ -3,6 +3,6 @@ title: "Neural correlates of sniffing and place in simultaneous recordings from 
 authors: "Rafilson et al."
 event: "Association for Chemoreception Sciences (AChemS)"
 year: 2025
-poster: "/assets/posters/AChemS 2025.pdf"
-slides: ""
+poster: "/assets/posters/AChemS_2025.pdf"
+slides:
 ---

--- a/_presentations/apa-2020-internet-addiction.md
+++ b/_presentations/apa-2020-internet-addiction.md
@@ -3,6 +3,6 @@ title: "Internet Addiction and its Correlates"
 authors: "Rafilson et al."
 event: "American Psychological Association (APA)"
 year: 2020
-poster: ""
-slides: ""
+poster:
+slides:
 ---

--- a/_presentations/sfn-2024-challenges-in-inferring.md
+++ b/_presentations/sfn-2024-challenges-in-inferring.md
@@ -3,6 +3,6 @@ title: "Challenges in inferring breathing rhythms from olfactory bulb local fiel
 authors: "Rafilson et al."
 event: "Society for Neuroscience (SfN)"
 year: 2024
-poster: "/assets/posters/SFN_2024.pdf"
-slides: ""
+poster: "/assets/posters/SFN_2025.png"
+slides:
 ---

--- a/_publications/rafilson-2025-chemicalsenses.md
+++ b/_publications/rafilson-2025-chemicalsenses.md
@@ -4,5 +4,5 @@ authors: "Rafilson et al."
 venue: "Chemical Senses"
 year: 2025
 doi: "https://doi.org/10.1101/2024.11.08.622727"
-pdf: ""
+pdf:
 ---

--- a/_publications/sterrett-2025-elife.md
+++ b/_publications/sterrett-2025-elife.md
@@ -4,5 +4,5 @@ authors: "Sterrett, Findley, Rafilson, et al."
 venue: "eLife"
 year: 2025
 doi: "https://doi.org/10.7554/eLife.105088.1"
-pdf: ""
+pdf:
 ---

--- a/index.md
+++ b/index.md
@@ -5,7 +5,7 @@ title: "Home"
 
 Hi, I'm **Sid Rafilson**, a Ph.D. student in Neuroscience at NYU. This site hosts my CV with links to publications, posters, and presentations.
 
-- 📄 See **[Publications](/publications/)**  
-- 🖼️ See **[Presentations & Posters](/presentations/)**  
+- 📄 See **[Publications]({{ '/publications/' | relative_url }})**
+- 🖼️ See **[Presentations & Posters]({{ '/presentations/' | relative_url }})**
 - 💻 GitHub: [Sid-Rafilson-1617](https://github.com/Sid-Rafilson-1617)  
 - ✉️ Email: <sid.rafilson@nyu.edu>

--- a/presentations.md
+++ b/presentations.md
@@ -9,8 +9,8 @@ permalink: /presentations/
 {% for item in sorted %}
   <li>
     <a href="{{ item.url | relative_url }}">{{ item.title }}</a> — {{ item.authors }}. <em>{{ item.event }}</em>, {{ item.year }}.
-    {% if item.poster %}<a href="{{ item.poster }}">[Poster]</a>{% endif %}
-    {% if item.slides %}<a href="{{ item.slides }}">[Slides]</a>{% endif %}
+    {% if item.poster != blank %}<a href="{{ item.poster | relative_url }}">[Poster]</a>{% endif %}
+    {% if item.slides != blank %}<a href="{{ item.slides | relative_url }}">[Slides]</a>{% endif %}
   </li>
 {% endfor %}
 </ul>

--- a/publications.md
+++ b/publications.md
@@ -9,8 +9,8 @@ permalink: /publications/
 {% for pub in sorted %}
   <li>
     <a href="{{ pub.url | relative_url }}">{{ pub.title }}</a> — {{ pub.authors }}. <em>{{ pub.venue }}</em>, {{ pub.year }}.
-    {% if pub.pdf %}<a href="{{ pub.pdf }}">[PDF]</a>{% endif %}
-    {% if pub.doi %}<a href="{{ pub.doi }}">[DOI]</a>{% endif %}
+    {% if pub.pdf != blank %}<a href="{{ pub.pdf | relative_url }}">[PDF]</a>{% endif %}
+    {% if pub.doi != blank %}<a href="{{ pub.doi }}">[DOI]</a>{% endif %}
   </li>
 {% endfor %}
 </ul>


### PR DESCRIPTION
## Summary
- use `relative_url` for publications and presentations links
- ensure templates handle missing assets and generate relative paths
- correct poster file paths for AChemS 2025 and SfN entries

## Testing
- `bundle install`
- `bundle exec jekyll build`


------
https://chatgpt.com/codex/tasks/task_e_68a3acb958588327bf03a8bd3eab3b08