### PR TITLE
Set base URL for Jekyll site

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -2,8 +2,8 @@ title: "Sidney Rafilson"
 email: "sid.rafilson@nyu.edu"
 description: >-
   CV with links to publications, posters, and presentations.
-baseurl: ""
-url: ""
+baseurl: "/CV"            # repository name
+url: "https://Sid-Rafilson-1617.github.io"
 theme: jekyll-theme-minimal
 plugins:
   - jekyll-feed


### PR DESCRIPTION
## Summary
- configure Jekyll to use repository path and GitHub Pages URL

## Testing
- `bundle install`
- `bundle exec jekyll serve --baseurl ""`


------
https://chatgpt.com/codex/tasks/task_e_68a3de30164c832798b4bcbf1347e1b8